### PR TITLE
updated routes for category pages

### DIFF
--- a/app/assets/javascripts/static.coffee
+++ b/app/assets/javascripts/static.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Static controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,9 @@
 class PagesController < ApplicationController
   def welcome
   end
+
+  def show
+    render params[:page]
+  end
+
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,0 +1,5 @@
+class StaticController < ApplicationController
+    def show
+        render params[:page]
+    end
+end

--- a/app/helpers/static_helper.rb
+++ b/app/helpers/static_helper.rb
@@ -1,0 +1,2 @@
+module StaticHelper
+end

--- a/app/views/pages/strings.html.erb
+++ b/app/views/pages/strings.html.erb
@@ -1,0 +1,1 @@
+<h1>This is the page for strings</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     sessions: 'users/sessions'
   }
+
+  get '/:page' => 'pages#show'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/test/controllers/static_controller_test.rb
+++ b/test/controllers/static_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StaticControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
can now create category pages and have them linked to via <%= link_to "[category]", "/[catgeory]" %>